### PR TITLE
Add support for oidc auth in k8s client

### DIFF
--- a/pkg/common/utils.go
+++ b/pkg/common/utils.go
@@ -32,6 +32,7 @@ import (
 	"strings"
 
 	"k8s.io/client-go/kubernetes"
+	_ "k8s.io/client-go/plugin/pkg/client/auth/oidc"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
 )


### PR DESCRIPTION
mapkubeapis fails when connecting to a cluster that uses oidc as auth method.

This change is essentially the implementation of https://github.com/helm/helm-mapkubeapis/pull/115

Withouh this a call to the cmd fails with:

`Error: failed to get release 'kube' latest version: query: failed to query with labels: no Auth Provider found for name "oidc"`

## Verification

```
make build
./bin/mapkubeapis -n <namespace> <release> --dry-run
```