### PR TITLE
Release 0.4.1-0.1.0

### DIFF
--- a/plugin.yaml
+++ b/plugin.yaml
@@ -1,5 +1,5 @@
 name: "mapkubeapis"
-version: "v0.1.0"
+version: "0.4.1-0.1.0"
 usage: "Map release deprecated Kubernetes APIs in-place"
 description: "Map release deprecated Kubernetes APIs in-place"
 command: "$HELM_PLUGIN_DIR/bin/mapkubeapis"

--- a/plugin.yaml
+++ b/plugin.yaml
@@ -1,5 +1,5 @@
 name: "mapkubeapis"
-version: "0.4.1"
+version: "v0.1.0"
 usage: "Map release deprecated Kubernetes APIs in-place"
 description: "Map release deprecated Kubernetes APIs in-place"
 command: "$HELM_PLUGIN_DIR/bin/mapkubeapis"


### PR DESCRIPTION
Cut first release of the plugin on kanopy-platform.

## Release process

- Merge this PR to master
- Tag master with v0.1.0 and push tag to origin
- Use goreleaser in local machine to generate artifacts
- Create a Release in github for the v0.1.0 tag and attach the artifacts generated by goreleaser.

Goreleaser can push the artifacts to github directly but I think for this one of release is not necessary to create a token to do that.

Here's a snaphot of what goreleaser will do. Replacing `0.0.0-SNAPSHOT-7431bf6` with `0.4.1-0.1.0` after the git tag is created.

```
❱ goreleaser release --snapshot --clean
  • starting release...
  • loading                                          path=.goreleaser.yml
  • skipping announce, publish and validate...
  • loading environment variables
  • getting and validating git state
    • ignoring errors because this is a snapshot     error=git doesn't contain any tags. Either add a tag or use --snapshot
    • git state                                      commit=7431bf6dc493c07a32e997c4c79fdb1cdf76c622 branch=main current_tag=v0.0.0 previous_tag=<unknown> dirty=false
    • pipe skipped                                   reason=disabled during snapshot mode
  • parsing tag
  • setting defaults
  • snapshotting
    • building snapshot...                           version=0.0.0-SNAPSHOT-7431bf6
  • checking distribution directory
  • loading go mod information
  • build prerequisites
  • writing effective config file
    • writing                                        config=dist/config.yaml
  • building binaries
    • building                                       binary=dist/helm-mapkubeapis_windows_arm64/mapkubeapis.exe
    • building                                       binary=dist/helm-mapkubeapis_linux_amd64_v1/mapkubeapis
    • building                                       binary=dist/helm-mapkubeapis_darwin_amd64_v1/mapkubeapis
    • building                                       binary=dist/helm-mapkubeapis_darwin_arm64/mapkubeapis
    • building                                       binary=dist/helm-mapkubeapis_linux_arm64/mapkubeapis
    • building                                       binary=dist/helm-mapkubeapis_windows_amd64_v1/mapkubeapis.exe
    • took: 56s
  • archives
    • creating                                       archive=dist/helm-mapkubeapis_0.0.0-SNAPSHOT-7431bf6_darwin_amd64.tar.gz
    • creating                                       archive=dist/helm-mapkubeapis_0.0.0-SNAPSHOT-7431bf6_windows_amd64.tar.gz
    • creating                                       archive=dist/helm-mapkubeapis_0.0.0-SNAPSHOT-7431bf6_windows_arm64.tar.gz
    • creating                                       archive=dist/helm-mapkubeapis_0.0.0-SNAPSHOT-7431bf6_linux_arm64.tar.gz
    • creating                                       archive=dist/helm-mapkubeapis_0.0.0-SNAPSHOT-7431bf6_linux_amd64.tar.gz
    • creating                                       archive=dist/helm-mapkubeapis_0.0.0-SNAPSHOT-7431bf6_darwin_arm64.tar.gz
    • took: 4s
  • calculating checksums
  • storing release metadata
    • writing                                        file=dist/artifacts.json
    • writing                                        file=dist/metadata.json
  • release succeeded after 59s
  • thanks for using goreleaser!
```  