### PR TITLE
Plugin versioning scheme fix and other minor changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,9 +24,9 @@
 Based on the version in `plugin.yaml`, release binary will be downloaded from GitHub:
 
 ```console
-$ helm plugin install https://github.com/helm/helm-mapkubeapis
-Downloading and installing helm-mapkubeapis v0.1.0 ...
-https://github.com/helm/helm-mapkubeapis/releases/download/v0.1.0/helm-mapkubeapis_0.1.0_darwin_amd64.tar.gz
+$ helm plugin install https://github.com/kanopy-platform/helm-mapkubeapis
+Downloading and installing helm-mapkubeapis v0.4.1-0.1.2 ...
+https://github.com/kanopy-platform/helm-mapkubeapis/releases/download/v0.4.1-0.1.2/helm-mapkubeapis_v0.4.1-0.1.2_darwin_amd64.tar.gz
 Installed plugin: mapkubeapis
 ```
 

--- a/plugin.yaml
+++ b/plugin.yaml
@@ -1,5 +1,5 @@
 name: "mapkubeapis"
-version: "0.4.1-0.1.1"
+version: "0.4.1-0.1.2"
 usage: "Map release deprecated Kubernetes APIs in-place"
 description: "Map release deprecated Kubernetes APIs in-place"
 command: "$HELM_PLUGIN_DIR/bin/mapkubeapis"

--- a/scripts/tag.sh
+++ b/scripts/tag.sh
@@ -4,7 +4,7 @@
 tag="$(cat plugin.yaml | grep "version" | cut -d '"' -f 2)"
 echo "Tagging helm-mapkubeapis with v${tag} ..."
 
-git checkout master
+git checkout main
 git pull
 git tag -a -m "Release v$tag" "v$tag" 
 git push origin refs/tags/v"$tag"


### PR DESCRIPTION
I didn't notice that the "tag" script, creates the tag with the `v` prefix which the goreleaser uses to create the github release.

At the moment the script installation fails because it is trying to get the release withouth the `v` prefix.

So for the release will use the "tag" script and then `goreleaser release` to keep the consistency.